### PR TITLE
Feature/resetwithnewfragments

### DIFF
--- a/app/src/main/java/com/trendyol/medusa/FragmentGenerator.kt
+++ b/app/src/main/java/com/trendyol/medusa/FragmentGenerator.kt
@@ -13,5 +13,11 @@ class FragmentGenerator {
             fragmentNumber++
             return SampleFragment.newInstance("fragment $fragmentNumber")
         }
+
+        @JvmStatic
+        fun generateBrandNewFragments(): Fragment {
+            fragmentNumber++
+            return SampleFragment.newInstance("brand new fragment $fragmentNumber")
+        }
     }
 }

--- a/app/src/main/java/com/trendyol/medusa/MainActivity.kt
+++ b/app/src/main/java/com/trendyol/medusa/MainActivity.kt
@@ -2,7 +2,6 @@ package com.trendyol.medusa
 
 import android.content.Intent
 import android.os.Bundle
-import android.os.PersistableBundle
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
@@ -15,7 +14,6 @@ import com.trendyol.medusalib.navigator.MultipleStackNavigator
 import com.trendyol.medusalib.navigator.Navigator
 import com.trendyol.medusalib.navigator.NavigatorConfiguration
 import com.trendyol.medusalib.navigator.transaction.NavigatorTransaction
-import com.trendyol.medusalib.navigator.transitionanimation.TransitionAnimationType
 
 class MainActivity : AppCompatActivity(), Navigator.NavigatorListener {
 
@@ -25,6 +23,12 @@ class MainActivity : AppCompatActivity(), Navigator.NavigatorListener {
         { FragmentGenerator.generateNewFragment() },
         { FragmentGenerator.generateNewFragment() },
         { FragmentGenerator.generateNewFragment() }
+    )
+
+    private val newListOfFragments: List<() -> Fragment> = listOf(
+        { FragmentGenerator.generateBrandNewFragments() },
+        { FragmentGenerator.generateBrandNewFragments() },
+        { FragmentGenerator.generateBrandNewFragments() }
     )
 
     val multipleStackNavigator: MultipleStackNavigator =
@@ -66,6 +70,10 @@ class MainActivity : AppCompatActivity(), Navigator.NavigatorListener {
 
         navigation.setOnNavigationItemSelectedListener(mOnNavigationItemSelectedListener)
         findViewById<Button>(R.id.reset).setOnClickListener { multipleStackNavigator.reset() }
+        findViewById<Button>(R.id.resetWithNewSet).setOnClickListener {
+            multipleStackNavigator.resetWithFragmentProvider(newListOfFragments)
+        }
+
     }
 
     override fun onBackPressed() {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -66,7 +66,10 @@
                     android:layout_weight="1"
                     android:singleLine="true"
                     android:text="Reset Current Tab" />
-
+            </LinearLayout>
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
                 <Button
                     android:id="@+id/resetXTab"
                     android:layout_width="0dp"
@@ -75,8 +78,14 @@
                     android:singleLine="true"
                     android:text="Reset X Tab" />
 
+                <Button
+                    android:id="@+id/resetWithNewSet"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:singleLine="true"
+                    android:text="Reset With New Fragments" />
             </LinearLayout>
-
         </LinearLayout>
     </RelativeLayout>
 

--- a/medusalib/build.gradle
+++ b/medusalib/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:4.3'
+    testImplementation 'com.google.truth:truth:1.0'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }

--- a/medusalib/src/main/java/com/trendyol/medusalib/navigator/FragmentStackState.kt
+++ b/medusalib/src/main/java/com/trendyol/medusalib/navigator/FragmentStackState.kt
@@ -60,7 +60,10 @@ data class FragmentStackState constructor(
     }
 
     fun popItemsFromNonEmptyTabs(): List<StackItem> {
-        return fragmentTagStack.filter { it.isNotEmpty() }.map { it.pop() }
+        return fragmentTagStack
+            .filter { it.isNotEmpty() }
+            .flatMap { stackItem -> stackItem.map { it } }
+            .also { fragmentTagStack.clear() }
     }
 
     fun insertTabToBottom(tabIndex: Int) {

--- a/medusalib/src/main/java/com/trendyol/medusalib/navigator/MultipleStackNavigator.kt
+++ b/medusalib/src/main/java/com/trendyol/medusalib/navigator/MultipleStackNavigator.kt
@@ -13,7 +13,7 @@ import com.trendyol.medusalib.navigator.transitionanimation.TransitionAnimationT
 open class MultipleStackNavigator(
     fragmentManager: FragmentManager,
     containerId: Int,
-    private val rootFragmentProvider: List<() -> Fragment>,
+    private var rootFragmentProvider: List<() -> Fragment>,
     private var navigatorListener: Navigator.NavigatorListener? = null,
     private val navigatorConfiguration: NavigatorConfiguration = NavigatorConfiguration(),
     private val transitionAnimationType: TransitionAnimationType? = null
@@ -156,6 +156,11 @@ open class MultipleStackNavigator(
         clearAllFragments()
         fragmentStackState.clear()
         initializeStackState()
+    }
+
+    override fun resetWithFragmentProvider(rootFragmentProvider: List<() -> Fragment>) {
+        this.rootFragmentProvider = rootFragmentProvider
+        reset()
     }
 
     override fun clearGroup(fragmentGroupName: String) {

--- a/medusalib/src/main/java/com/trendyol/medusalib/navigator/Navigator.kt
+++ b/medusalib/src/main/java/com/trendyol/medusalib/navigator/Navigator.kt
@@ -117,6 +117,12 @@ interface Navigator {
     fun reset()
 
     /**
+     * Resets all tabs and Navigator history and
+     * creates a new one with given fragment provider.
+     */
+    fun resetWithFragmentProvider(rootFragmentProvider: List<() -> Fragment>)
+
+    /**
      * Clears all fragments with given group name in the
      * current tab. This method aims to clear all
      * related/steps fragments from tab.

--- a/medusalib/src/main/java/com/trendyol/medusalib/navigator/controller/FragmentManagerController.kt
+++ b/medusalib/src/main/java/com/trendyol/medusalib/navigator/controller/FragmentManagerController.kt
@@ -135,7 +135,7 @@ class FragmentManagerController(private val fragmentManager: FragmentManager,
     fun findFragmentByTagAndRemove(fragmentTag: String) {
         checkAndCreateTransaction()
 
-        getFragment(fragmentTag)?.let { currentTransaction?.remove(it) }
+        getFragmentWithExecutingPendingTransactionsIfNeeded(fragmentTag)?.let { currentTransaction?.remove(it) }
     }
 
     private fun commitShow(fragmentTag: String) {

--- a/medusalib/src/test/java/com/trendyol/medusalib/navigator/FragmentStackStateData.kt
+++ b/medusalib/src/test/java/com/trendyol/medusalib/navigator/FragmentStackStateData.kt
@@ -1,0 +1,29 @@
+package com.trendyol.medusalib.navigator
+
+import com.trendyol.medusalib.navigator.data.StackItem
+import java.util.*
+
+
+fun buildFragmentStackState(stackItems: MutableList<Stack<StackItem>> = buildStackItems()): FragmentStackState {
+    return FragmentStackState(
+        stackItems,
+        Stack<Int>().apply {
+            push(2)
+            push(1)
+            push(0)
+        }
+    )
+}
+
+fun buildStackItems() = mutableListOf(
+    Stack<StackItem>().apply { push(StackItem("TAG1", "GROUP")) },
+    Stack<StackItem>().apply {
+        push(StackItem("TAG2", "GROUP"))
+        push(StackItem("TAG3", "GROUP"))
+    },
+    Stack<StackItem>().apply {
+        push(StackItem("TAG4", "GROUP"))
+        push(StackItem("TAG5", "GROUP"))
+        push(StackItem("TAG6", "GROUP"))
+    }
+)

--- a/medusalib/src/test/java/com/trendyol/medusalib/navigator/FragmentStackStateMapperTest.kt
+++ b/medusalib/src/test/java/com/trendyol/medusalib/navigator/FragmentStackStateMapperTest.kt
@@ -1,13 +1,10 @@
 package com.trendyol.medusalib.navigator
 
-import com.trendyol.medusalib.navigator.data.StackItem
-import org.junit.Assert
 import org.junit.Test
 
 import org.junit.Assert.*
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.util.*
 
 @RunWith(RobolectricTestRunner::class)
 class FragmentStackStateMapperTest {
@@ -23,25 +20,4 @@ class FragmentStackStateMapperTest {
         assertEquals(fragmentStackState, unserializedFragmentStackState)
     }
 
-    private fun buildFragmentStackState(): FragmentStackState {
-        return FragmentStackState(
-            mutableListOf(
-                Stack<StackItem>().apply { push(StackItem("TAG1", "GROUP")) },
-                Stack<StackItem>().apply {
-                    push(StackItem("TAG2", "GROUP"))
-                    push(StackItem("TAG3", "GROUP"))
-                },
-                Stack<StackItem>().apply {
-                    push(StackItem("TAG4", "GROUP"))
-                    push(StackItem("TAG5", "GROUP"))
-                    push(StackItem("TAG6", "GROUP"))
-                }
-            ),
-            Stack<Int>().apply {
-                push(2)
-                push(1)
-                push(0)
-            }
-        )
-    }
 }

--- a/medusalib/src/test/java/com/trendyol/medusalib/navigator/FragmentStackStateTest.kt
+++ b/medusalib/src/test/java/com/trendyol/medusalib/navigator/FragmentStackStateTest.kt
@@ -1,0 +1,21 @@
+package com.trendyol.medusalib.navigator
+
+import com.google.common.truth.Truth
+import com.trendyol.medusalib.navigator.data.StackItem
+import org.junit.Assert.*
+import org.junit.Test
+
+class FragmentStackStateTest {
+
+    @Test
+    fun `popItemsFromNonEmptyTabs returns all of the stack items in given stack`() {
+        val stackItems = buildStackItems()
+        val stackState = buildFragmentStackState(stackItems)
+        val expectedStackItems = mutableListOf<StackItem>()
+        stackItems.forEach { it.forEach { expectedStackItems.add(it) } }
+
+        val actualPoppedItems = stackState.popItemsFromNonEmptyTabs()
+
+        Truth.assertThat(actualPoppedItems).containsExactly(expectedStackItems)
+    }
+}

--- a/medusalib/src/test/java/com/trendyol/medusalib/navigator/FragmentStackStateTest.kt
+++ b/medusalib/src/test/java/com/trendyol/medusalib/navigator/FragmentStackStateTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth
 import com.trendyol.medusalib.navigator.data.StackItem
 import org.junit.Assert.*
 import org.junit.Test
+import java.util.*
 
 class FragmentStackStateTest {
 
@@ -17,5 +18,15 @@ class FragmentStackStateTest {
         val actualPoppedItems = stackState.popItemsFromNonEmptyTabs()
 
         Truth.assertThat(actualPoppedItems).containsExactly(expectedStackItems)
+    }
+
+    @Test
+    fun `popItemsFromNonEmptyTabs clears stack item in given stack`() {
+        val stackState = buildFragmentStackState()
+        val emptyStack = emptyList<Stack<StackItem>>()
+
+        stackState.popItemsFromNonEmptyTabs()
+
+        Truth.assertThat(stackState.fragmentTagStack).containsExactly(emptyStack)
     }
 }

--- a/medusalib/src/test/java/com/trendyol/medusalib/navigator/FragmentStackStateTest.kt
+++ b/medusalib/src/test/java/com/trendyol/medusalib/navigator/FragmentStackStateTest.kt
@@ -17,7 +17,7 @@ class FragmentStackStateTest {
 
         val actualPoppedItems = stackState.popItemsFromNonEmptyTabs()
 
-        Truth.assertThat(actualPoppedItems).containsExactly(expectedStackItems)
+        Truth.assertThat(actualPoppedItems).containsExactlyElementsIn(expectedStackItems)
     }
 
     @Test
@@ -27,6 +27,6 @@ class FragmentStackStateTest {
 
         stackState.popItemsFromNonEmptyTabs()
 
-        Truth.assertThat(stackState.fragmentTagStack).containsExactly(emptyStack)
+        Truth.assertThat(stackState.fragmentTagStack).containsExactlyElementsIn(emptyStack)
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix popItemsFromNonEmptyTabs function bug by iterating all of the stacks in lists. 
Add new function to Navigator interface that resets fragments and fragment stack state of navigator and initialize a new fragment stack state with given fragment provider.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Fix 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
