### PR TITLE
- Fix tab order bug by removing switchTab call in notifyStackItemAdd.

### DIFF
--- a/medusalib/src/test/java/com/trendyol/medusalib/navigator/FragmentStackStateTest.kt
+++ b/medusalib/src/test/java/com/trendyol/medusalib/navigator/FragmentStackStateTest.kt
@@ -28,22 +28,4 @@ class FragmentStackStateTest {
 
         Truth.assertThat(stackState.fragmentTagStack).containsExactlyElementsIn(emptyStack)
     }
-
-    @Test
-    fun `given stackstate with tab index stack of (2, 1, 0), when addStackItem is called with tabIndex 1, then new tab index must be (2, 0, 1)`() {
-        val stackState = buildFragmentStackState(tabStack = buildTabStack(2, 1, 0))
-
-        stackState.addStackItem(1, buildStackItem())
-
-        Truth.assertThat(stackState.tabIndexStack).containsExactly(2, 0, 1).inOrder()
-    }
-
-    @Test
-    fun `given stackstate with tab index stack of (2, 1, 0), when addStackItem is called with tabIndex 0, then new tab index must be (2, 1, 0)`() {
-        val stackState = buildFragmentStackState(tabStack = buildTabStack(2, 1, 0))
-
-        stackState.addStackItem(0, buildStackItem())
-
-        Truth.assertThat(stackState.tabIndexStack).containsExactly(2, 1, 0).inOrder()
-    }
 }


### PR DESCRIPTION
- Fix tab order bug by removing switchTab call in notifyStackItemAdd.
- Start calling switchTab in resetCurrentTab function in order to notify stackState. This is needed because clearAllFragments pops tabIndex in tab index stack when fragment stack for that tab is empty.
- Set stack count in initializeStackState method in order to create empty fragment stacks at initialization. Previous to this in order to create fragment stacks we were using root fragment provider and calling addStackItem method for each root fragment.
- Start initializing root fragments when it is needed, ie. switchTab.

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
