### PR TITLE
saved state: check for empty tab stack while loading stack from bundle

### DIFF
--- a/medusalib/src/main/java/com/trendyol/medusalib/navigator/MultipleStackNavigator.kt
+++ b/medusalib/src/main/java/com/trendyol/medusalib/navigator/MultipleStackNavigator.kt
@@ -221,7 +221,9 @@ open class MultipleStackNavigator(
     private fun loadStackStateFromSavedState(savedState: Bundle) {
         val stackState = fragmentStackStateMapper.fromBundle(savedState.getBundle(MEDUSA_STACK_STATE_KEY))
         fragmentStackState.setStackState(stackState)
-        navigatorListener?.onTabChanged(fragmentStackState.getSelectedTabIndex())
+        if (stackState.tabIndexStack.isNotEmpty()) {
+            navigatorListener?.onTabChanged(fragmentStackState.getSelectedTabIndex())
+        }
     }
 
     private fun getRootFragment(tabIndex: Int): Fragment {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
If savedState is null, FragmentStackState instance has an empty tab index stack by default.
In this case, invoking fragmentStackState.getSelectedTabIndex() will throw an exception as the stack is empty.
Hence, check if tab index stack is empty before accessing it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
