### PR TITLE
Destination changed

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,10 +11,16 @@ android {
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+    kotlinOptions { jvmTarget = "1.8" }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
         }
     }
 }
@@ -28,9 +34,13 @@ dependencies {
     implementation 'androidx.vectordrawable:vectordrawable:1.1.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.robolectric:robolectric:4.8.1'
+    testImplementation 'androidx.arch.core:core-testing:2.1.0'
+    testImplementation 'androidx.test.ext:junit:1.1.3'
+    testImplementation 'androidx.test:core-ktx:1.4.0'
+    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }
 repositories {
     mavenCentral()

--- a/app/src/main/java/com/trendyol/medusa/MainActivity.kt
+++ b/app/src/main/java/com/trendyol/medusa/MainActivity.kt
@@ -2,6 +2,7 @@ package com.trendyol.medusa
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
@@ -72,6 +73,10 @@ class MainActivity : AppCompatActivity(), Navigator.NavigatorListener {
         findViewById<Button>(R.id.reset).setOnClickListener { multipleStackNavigator.reset() }
         findViewById<Button>(R.id.resetWithNewSet).setOnClickListener {
             multipleStackNavigator.resetWithFragmentProvider(newListOfFragments)
+        }
+
+        multipleStackNavigator.observeDestinationChanges(this) {
+            Log.d("Destination Changed", "${it.javaClass.name} - ${it.tag}")
         }
 
     }

--- a/app/src/main/java/com/trendyol/medusa/SampleFragment.kt
+++ b/app/src/main/java/com/trendyol/medusa/SampleFragment.kt
@@ -37,6 +37,10 @@ class SampleFragment : BaseFragment() {
             fragment.arguments = bundle
             return fragment
         }
+
+        fun from(fragment: SampleFragment): String? {
+            return fragment.arguments?.getString(KEY)
+        }
     }
 
 }

--- a/app/src/test/java/com/trendyol/medusa/DestinationListenerTest.kt
+++ b/app/src/test/java/com/trendyol/medusa/DestinationListenerTest.kt
@@ -1,0 +1,216 @@
+package com.trendyol.medusa
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.launchActivity
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.trendyol.medusalib.navigator.MultipleStackNavigator
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+
+@RunWith(AndroidJUnit4::class)
+class DestinationListenerTest {
+
+
+    @Rule
+    @JvmField
+    val instantExecutorRule = InstantTaskExecutorRule()
+
+    @Before
+    fun setup() {
+        FragmentGenerator.fragmentNumber = 0
+    }
+
+    @Test
+    fun `given activity is resumed, when observeDestinationChanges is called, last destination must be emitted`() {
+        val testObserver = TestObserver<Fragment>()
+        launchActivity<MainActivity>().use { scenario ->
+            // given
+            scenario.moveToState(Lifecycle.State.RESUMED)
+
+            // when
+            scenario.onActivity { activity ->
+                activity.doAndExecuteFragmentTransactions {
+                    observeDestinationChanges(activity, testObserver)
+                }
+
+                // then
+                Assert.assertEquals(
+                    "fragment 1",
+                    testObserver.values.single().getFragmentName()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `given navigator is at second tab, when switchTab is called with index 0, then last two observed values of destination listener must be 2 and 1`() {
+        val testObserver = TestObserver<Fragment>()
+        launchActivity<MainActivity>().use { scenario ->
+            // Given
+            scenario.moveToState(Lifecycle.State.RESUMED)
+            scenario.onActivity { activity ->
+                activity.doAndExecuteFragmentTransactions {
+                    switchTab(1)
+                    observeDestinationChanges(activity, testObserver)
+                }
+
+                // when
+                activity.doAndExecuteFragmentTransactions {
+                    switchTab(0)
+                }
+
+                // then
+                Assert.assertEquals(
+                    "fragment 1",
+                    testObserver.getLastFragmentName(indexFromLast = 1)
+                )
+                Assert.assertEquals(
+                    "fragment 2",
+                    testObserver.getLastFragmentName(0)
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `given a fragment is started after root fragment, when onBackPressed called, then fragment history must be 1-2-1`() {
+        val testObserver = TestObserver<Fragment>()
+        launchActivity<MainActivity>().use { scenario ->
+            // Given
+            scenario.moveToState(Lifecycle.State.RESUMED)
+            scenario.onActivity { activity ->
+                activity.doAndExecuteFragmentTransactions {
+                    observeDestinationChanges(activity, testObserver)
+                    start(FragmentGenerator.generateNewFragment())
+                }
+
+                activity.onBackPressed()
+                activity.supportFragmentManager.executePendingTransactions()
+
+                Assert.assertEquals("fragment 1", testObserver.getFragmentName(0))
+                Assert.assertEquals("fragment 2", testObserver.getFragmentName(1))
+                Assert.assertEquals("fragment 1", testObserver.getFragmentName(2))
+            }
+        }
+    }
+
+    @Test
+    fun `given a fragment is started after root fragment, when switchTabIs called, then fragment history must be 1-2-3`() {
+        val testObserver = TestObserver<Fragment>()
+        launchActivity<MainActivity>().use { scenario ->
+            // Given
+            scenario.moveToState(Lifecycle.State.RESUMED)
+            scenario.onActivity { activity ->
+                activity.doAndExecuteFragmentTransactions {
+                    observeDestinationChanges(activity, testObserver)
+                    start(FragmentGenerator.generateNewFragment())
+                }
+
+                activity.doAndExecuteFragmentTransactions { switchTab(0) }
+
+                Assert.assertEquals(
+                    "fragment 1",
+                    testObserver.getLastFragmentName(indexFromLast = 2)
+                )
+                Assert.assertEquals(
+                    "fragment 2",
+                    testObserver.getLastFragmentName(indexFromLast = 1)
+                )
+                Assert.assertEquals("fragment 3", testObserver.getLastFragmentName())
+            }
+        }
+    }
+
+    @Test
+    fun `given a fragment is started after root fragment and switched another tab, when onBackPressed is called, then fragment history must be 1-2-3-2`() {
+        val testObserver = TestObserver<Fragment>()
+        launchActivity<MainActivity>().use { scenario ->
+            // Given
+            scenario.moveToState(Lifecycle.State.RESUMED)
+            scenario.onActivity { activity ->
+                activity.doAndExecuteFragmentTransactions {
+                    observeDestinationChanges(activity, testObserver)
+                    start(FragmentGenerator.generateNewFragment())
+                    switchTab(0)
+                }
+
+                activity.onBackPressed()
+                activity.supportFragmentManager.executePendingTransactions()
+
+                Assert.assertEquals(
+                    "fragment 1",
+                    testObserver.getLastFragmentName(indexFromLast = 3)
+                )
+                Assert.assertEquals(
+                    "fragment 2",
+                    testObserver.getLastFragmentName(indexFromLast = 2)
+                )
+                Assert.assertEquals(
+                    "fragment 3",
+                    testObserver.getLastFragmentName(indexFromLast = 1)
+                )
+                Assert.assertEquals("fragment 2", testObserver.getLastFragmentName())
+            }
+        }
+    }
+
+    @Test
+    fun `given all three tabs are visited, when onBackPressed is called twice, then fragment history must be 1-2-3-2-1`() {
+        val testObserver = TestObserver<Fragment>()
+        launchActivity<MainActivity>().use { scenario ->
+            // Given
+            scenario.moveToState(Lifecycle.State.RESUMED)
+
+            scenario.onActivity { activity ->
+                activity.multipleStackNavigator.observeDestinationChanges(activity, testObserver)
+                activity.doAndExecuteFragmentTransactions {
+                    switchTab(0)
+                }
+                activity.doAndExecuteFragmentTransactions {
+                    switchTab(2)
+                }
+
+                activity.onBackPressed()
+                activity.supportFragmentManager.executePendingTransactions()
+                activity.onBackPressed()
+                activity.supportFragmentManager.executePendingTransactions()
+
+                Assert.assertEquals(
+                    "fragment 1",
+                    testObserver.getLastFragmentName(indexFromLast = 4)
+                )
+                Assert.assertEquals(
+                    "fragment 2",
+                    testObserver.getLastFragmentName(indexFromLast = 3)
+                )
+                Assert.assertEquals(
+                    "fragment 3",
+                    testObserver.getLastFragmentName(indexFromLast = 2)
+                )
+                Assert.assertEquals(
+                    "fragment 2",
+                    testObserver.getLastFragmentName(indexFromLast = 1)
+                )
+                Assert.assertEquals("fragment 1", testObserver.getLastFragmentName())
+            }
+        }
+    }
+    private fun MainActivity.doAndExecuteFragmentTransactions(run: MultipleStackNavigator.() -> Unit) =
+        run.invoke(this.multipleStackNavigator).also { supportFragmentManager.executePendingTransactions() }
+
+    private fun TestObserver<Fragment>.getLastFragmentName(indexFromLast: Int = 0) =
+        values[values.lastIndex - indexFromLast].getFragmentName()
+
+    private fun TestObserver<Fragment>.getFragmentName(index: Int) =
+        values[index].getFragmentName()
+
+    private fun Fragment.getFragmentName() =
+        SampleFragment.from(this as SampleFragment)
+}
+

--- a/app/src/test/java/com/trendyol/medusa/TestObserver.kt
+++ b/app/src/test/java/com/trendyol/medusa/TestObserver.kt
@@ -1,0 +1,9 @@
+package com.trendyol.medusa
+
+class TestObserver<T> constructor() : (T) -> Unit {
+    val values = mutableListOf<T>()
+
+    override fun invoke(p1: T) {
+        values.add(p1)
+    }
+}

--- a/medusalib/build.gradle
+++ b/medusalib/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-
+    implementation "androidx.lifecycle:lifecycle-common:2.4.1"
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation 'com.google.truth:truth:1.0'

--- a/medusalib/src/main/java/com/trendyol/medusalib/navigator/MultipleStackNavigator.kt
+++ b/medusalib/src/main/java/com/trendyol/medusalib/navigator/MultipleStackNavigator.kt
@@ -316,6 +316,9 @@ open class MultipleStackNavigator(
                         }
 
                         override fun onDestroy(owner: LifecycleOwner) {
+                            if (destinationChangeLiveData.value == fragment) {
+                                destinationChangeLiveData.value = null
+                            }
                             owner.lifecycle.removeObserver(this)
                         }
                     }

--- a/medusalib/src/main/java/com/trendyol/medusalib/navigator/Navigator.kt
+++ b/medusalib/src/main/java/com/trendyol/medusalib/navigator/Navigator.kt
@@ -2,6 +2,7 @@ package com.trendyol.medusalib.navigator
 
 import android.os.Bundle
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.LifecycleOwner
 import com.trendyol.medusalib.navigator.transaction.NavigatorTransaction
 import com.trendyol.medusalib.navigator.transitionanimation.TransitionAnimationType
 
@@ -163,6 +164,18 @@ interface Navigator {
     /**
      * Listeners
      */
+
+    /*
+    Observes any changes made in fragment back stack with the given lifecycle.
+    All implementation of Navigator interface must guarantee following points:
+    - View lifecycle of the fragments that is observed by the listener must be at least in
+    STARTED state.
+
+    - destinationChangedListener must be removed when the given lifecycle owner is reached
+    DESTROYED state
+     */
+    fun observeDestinationChanges(lifecycleOwner: LifecycleOwner,
+                                  destinationChangedListener: (Fragment) -> Unit)
 
     interface NavigatorListener {
 

--- a/medusalib/src/main/java/com/trendyol/medusalib/navigator/controller/FragmentManagerController.kt
+++ b/medusalib/src/main/java/com/trendyol/medusalib/navigator/controller/FragmentManagerController.kt
@@ -104,10 +104,6 @@ class FragmentManagerController(private val fragmentManager: FragmentManager,
         currentTransaction?.setCustomAnimations(enter, exit)
     }
 
-    fun isFragmentNull(fragmentTag: String): Boolean {
-        return getFragment(fragmentTag) == null
-    }
-
     private fun getFragmentWithExecutingPendingTransactionsIfNeeded(fragmentTag: String): Fragment? {
         var fragment = getFragment(fragmentTag)
         if (fragment == null && fragmentManager.executePendingTransactions()) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Introduces destination change listener to listen destination changes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Added a new function called observeDestinationChanges to observe any changes made in Medusa backstack

## Motivation and Context
We need to track which fragment is started or reappeared. This used to be achievable by overriding onHiddenChange and onViewCreated functions in fragment instances but we wanted to offer a new way for navigator owner level (ie. activity) 

## How Has This Been Tested?
Created a DestinationListenerTest class also manuel testing.

## Screenshots (if appropriate):

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
