### PR TITLE
Observe destination changes clear group bug

### DIFF
--- a/app/src/main/java/com/trendyol/medusa/MainActivity.kt
+++ b/app/src/main/java/com/trendyol/medusa/MainActivity.kt
@@ -66,19 +66,27 @@ class MainActivity : AppCompatActivity(), Navigator.NavigatorListener {
 
         multipleStackNavigator.initialize(savedInstanceState)
         val restartRootFragmentCheckBox = findViewById<View>(R.id.restartSwitch) as SwitchCompat
-        findViewById<Button>(R.id.resetCurrentTab).setOnClickListener { multipleStackNavigator.resetCurrentTab(restartRootFragmentCheckBox.isChecked) }
-        findViewById<Button>(R.id.resetXTab).setOnClickListener { multipleStackNavigator.reset(1, restartRootFragmentCheckBox.isChecked) }
+        findViewById<Button>(R.id.resetCurrentTab).setOnClickListener {
+            multipleStackNavigator.resetCurrentTab(restartRootFragmentCheckBox.isChecked)
+        }
+        findViewById<Button>(R.id.resetXTab).setOnClickListener {
+            multipleStackNavigator.reset(1, restartRootFragmentCheckBox.isChecked)
+        }
 
         navigation.setOnNavigationItemSelectedListener(mOnNavigationItemSelectedListener)
         findViewById<Button>(R.id.reset).setOnClickListener { multipleStackNavigator.reset() }
         findViewById<Button>(R.id.resetWithNewSet).setOnClickListener {
             multipleStackNavigator.resetWithFragmentProvider(newListOfFragments)
         }
-
+        findViewById<Button>(R.id.startWithGroup).setOnClickListener {
+            multipleStackNavigator.start(FragmentGenerator.generateNewFragment(), "group1")
+        }
+        findViewById<Button>(R.id.resetGroup).setOnClickListener {
+            multipleStackNavigator.clearGroup("group1")
+        }
         multipleStackNavigator.observeDestinationChanges(this) {
             Log.d("Destination Changed", "${it.javaClass.name} - ${it.tag}")
         }
-
     }
 
     override fun onBackPressed() {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -86,6 +86,27 @@
                     android:singleLine="true"
                     android:text="Reset With New Fragments" />
             </LinearLayout>
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <Button
+                    android:id="@+id/startWithGroup"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:singleLine="true"
+                    android:text="Start With Group" />
+
+                <Button
+                    android:id="@+id/resetGroup"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:singleLine="true"
+                    android:text="Reset Group" />
+            </LinearLayout>
+
         </LinearLayout>
     </RelativeLayout>
 

--- a/medusalib/build.gradle
+++ b/medusalib/build.gradle
@@ -29,7 +29,7 @@ android {
 
 ext {
     PUBLISH_GROUP_ID = 'com.trendyol'
-    PUBLISH_VERSION = '0.10.3'
+    PUBLISH_VERSION = '0.10.4'
     PUBLISH_ARTIFACT_ID = 'medusa'
     PUBLISH_DESCRIPTION = "Android Fragment Stack Controller"
     PUBLISH_URL = "https://github.com/Trendyol/medusa"

--- a/medusalib/src/main/java/com/trendyol/medusalib/navigator/MultipleStackNavigator.kt
+++ b/medusalib/src/main/java/com/trendyol/medusalib/navigator/MultipleStackNavigator.kt
@@ -175,13 +175,18 @@ open class MultipleStackNavigator(
         if (fragmentGroupName == DEFAULT_GROUP_NAME) {
             throw IllegalArgumentException("Fragment group name can not be empty.")
         }
+        val upperFragmentTag = fragmentStackState.peekItemFromSelectedTab()?.fragmentTag
+
         val poppedFragmentTags = fragmentStackState
             .popItems(fragmentGroupName)
             .map { it.fragmentTag }
 
         if (poppedFragmentTags.isNotEmpty()) {
             fragmentManagerController.removeFragments(poppedFragmentTags)
-            showUpperFragment()
+            val poppedUpperFragment = poppedFragmentTags.contains(upperFragmentTag)
+            if (poppedUpperFragment) {
+                showUpperFragment()
+            }
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Reproduction Steps:

Call observeDestinationChanges to observe destination changes.
Start a fragment.
Start a fragment with groupName.
Start another fragment.
Call clearGroup to remove the second fragment.
Expected Result:
The callback passed into observeDestinationChanges should not be triggered because the destination hasn't changed.

Actual Result:
The callback is triggered.

## Motivation and Context
Fixes a bug.

## How Has This Been Tested?
Manual + Unit tests

## Screenshots (if appropriate):

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
