### PR TITLE
Add a new workflow for publishing new versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: Publish
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - name: Run unit tests
+        uses: gradle/gradle-build-action@v2.7.0
+        with:
+          arguments: testDebugUnitTest
+
+      - name: Publish
+        uses: gradle/gradle-build-action@v2.7.0
+        with:
+          arguments: publish
+        env:
+          SIGNING_KEY: ${{ secrets.SONARTYPE_GPG_PRIVATE_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.SONARTYPE_GPG_PASSPHRASE }}
+          OSSRH_USERNAME: ${{ secrets.SONARTYPE_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.SONARTYPE_PASSWORD }}
+          SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}

--- a/scripts/publish-root.gradle
+++ b/scripts/publish-root.gradle
@@ -1,24 +1,9 @@
-ext["signing.keyId"] = ''
-ext["signing.password"] = ''
-ext["signing.key"] = ''
-ext["ossrhUsername"] = ''
-ext["ossrhPassword"] = ''
-ext["sonatypeStagingProfileId"] = ''
-
-File propertiesFile = project.rootProject.file('local.properties')
-
-if (propertiesFile.exists()) {
-    Properties p = new Properties()
-    new FileInputStream(propertiesFile).withCloseable { is -> p.load(is) }
-    p.each { name, value -> ext[name] = value }
-} else {
-    ext["ossrhUsername"] = System.getenv('OSSRH_USERNAME')
-    ext["ossrhPassword"] = System.getenv('OSSRH_PASSWORD')
-    ext["sonatypeStagingProfileId"] = System.getenv('SONATYPE_STAGING_PROFILE_ID')
-    ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
-    ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
-    ext["signing.key"] = System.getenv('SIGNING_KEY')
-}
+ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
+ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
+ext["signing.key"] = System.getenv('SIGNING_KEY')
+ext["ossrhUsername"] = System.getenv('OSSRH_USERNAME')
+ext["ossrhPassword"] = System.getenv('OSSRH_PASSWORD')
+ext["sonatypeStagingProfileId"] = System.getenv('SONATYPE_STAGING_PROFILE_ID')
 
 nexusPublishing {
     repositories {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add a new workflow that publishes new releases.

Remove the code that reads these secrets from the local.properties file. This will prevent or at least make it harder for developers to publish new versions from their development machines

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
"The 'publish' workflow is triggered on new releases. It sets up an environment, runs unit tests, and publishes the new version of the library by invoking 'publish' on Gradle. In the final step, we retrieve credentials and signing info from GitHub secrets, set them as environment variables. The 'publish-root.gradle' then uses these environment variables to publish the new release."

## Motivation and Context
I want to automate publish new version process.

## How Has This Been Tested?
I tested using Act. 

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
