### PR TITLE
FixIllegalStateExceptionConcurrentTransaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - This changelog file
+- Fix a bug where a fragment that we want to hide is not added to the fragment manager,
+causing an IllegalStateException due to multiple fragment transactions occurring simultaneously 
+because of the executePendingTransactions() method call
 
 ### Changed
 

--- a/gradle/libs.toml
+++ b/gradle/libs.toml
@@ -13,9 +13,11 @@ androidXArchCoreTesting = "androidx.arch.core:core-testing:2.2.0"
 androidXFragmentTesting = "androidx.fragment:fragment-testing:1.8.0"
 androidXTestCoreKtx = "androidx.test:core-ktx:1.4.0"
 androidXTestExtJunit = "androidx.test.ext:junit:1.1.3"
+androidXTestRunner = "androidx.test:runner:1.5.2"
 junit = "junit:junit:4.13.2"
 robolectric = "org.robolectric:robolectric:4.12.2"
 truth = "com.google.truth:truth:1.4.2"
+espressoTest = "androidx.test.espresso:espresso-core:3.6.0"
 
 [versions]
 kotlin = "2.0.0"

--- a/medusalib/build.gradle
+++ b/medusalib/build.gradle
@@ -57,6 +57,14 @@ dependencies {
     testImplementation libs.junit
     testImplementation libs.robolectric
     testImplementation libs.truth
+
+    androidTestImplementation libs.androidXTestExtJunit
+    androidTestImplementation libs.androidXTestRunner
+    debugImplementation libs.androidXFragmentTesting
+    androidTestImplementation libs.truth
+    androidTestImplementation libs.junit
+    androidTestImplementation libs.espressoTest
+
 }
 
 repositories {

--- a/medusalib/src/androidTest/java/com/trendyol/medusalib/TestChildFragment.kt
+++ b/medusalib/src/androidTest/java/com/trendyol/medusalib/TestChildFragment.kt
@@ -1,0 +1,36 @@
+package com.trendyol.medusalib
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+
+private const val KEY_TITLE = "title"
+
+class TestChildFragment : Fragment() {
+
+    var onFragmentVisibleAgain: (() -> Unit)? = null
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return TextView(requireContext()).apply {
+            text = requireArguments().getString(KEY_TITLE)
+        }
+    }
+
+    override fun onHiddenChanged(hidden: Boolean) {
+        super.onHiddenChanged(hidden)
+        if (hidden.not() && view != null) {
+            onFragmentVisibleAgain?.invoke()
+        }
+    }
+
+    companion object {
+        fun newInstance(title: String): TestChildFragment {
+            return TestChildFragment().apply {
+                arguments = Bundle().apply { putString(KEY_TITLE, title) }
+            }
+        }
+    }
+}

--- a/medusalib/src/androidTest/java/com/trendyol/medusalib/TestParentFragment.kt
+++ b/medusalib/src/androidTest/java/com/trendyol/medusalib/TestParentFragment.kt
@@ -1,0 +1,19 @@
+package com.trendyol.medusalib
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.fragment.app.Fragment
+
+class TestParentFragment : Fragment() {
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return FrameLayout(requireContext()).apply { id = CONTAINER_ID }
+    }
+
+    companion object {
+        const val CONTAINER_ID = 1_000
+    }
+}

--- a/medusalib/src/androidTest/java/com/trendyol/medusalib/navigator/ConcurrentTransactionTest.kt
+++ b/medusalib/src/androidTest/java/com/trendyol/medusalib/navigator/ConcurrentTransactionTest.kt
@@ -1,0 +1,83 @@
+package com.trendyol.medusalib.navigator
+
+import androidx.fragment.app.testing.FragmentScenario
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.fragment.app.testing.withFragment
+import androidx.lifecycle.Lifecycle
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.trendyol.medusalib.TestChildFragment
+import com.trendyol.medusalib.TestParentFragment
+import com.trendyol.medusalib.navigator.transaction.NavigatorTransaction
+import com.trendyol.medusalib.navigator.transaction.TransactionType
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+
+
+@RunWith(AndroidJUnit4::class)
+class ConcurrentTransactionTest {
+
+    @Test
+    fun givenNavigatorWithShowAndHideWhenFragmentResetsTheCurrentTabAndStartsAnotherFragmentThenItMustNotThrowAnyExceptions() {
+        // Given
+        val transaction = CountDownLatch(1)
+        var caughtException: Throwable? = null
+        var navigator: Navigator? = null
+        val scenario = launchFragmentInContainer<TestParentFragment>(
+            initialState = Lifecycle.State.INITIALIZED
+        )
+        scenario.moveToState(Lifecycle.State.RESUMED)
+        val rootFragment = TestChildFragment.newInstance("Root")
+        val expectedFragment = TestChildFragment.newInstance("ExpectedFragment")
+
+        scenario.withFragment { navigator = createNavigator(rootFragment = rootFragment) }
+        scenario.moveToState(Lifecycle.State.RESUMED)
+
+        // When
+        rootFragment.onFragmentVisibleAgain = {
+            resetTabAndStartFragment(navigator!!, expectedFragment)
+                .onSuccess { transaction.countDown() }
+                .onFailure {
+                    caughtException = it
+                    transaction.countDown()
+                }
+        }
+        scenario.startAndDismissAFragment(navigator!!)
+
+        transaction.await()
+        caughtException?.let { throw it }
+        scenario.moveToState(Lifecycle.State.RESUMED)
+        onView(withText("ExpectedFragment")).check(matches(isDisplayed()))
+    }
+
+    private fun FragmentScenario<TestParentFragment>.startAndDismissAFragment(navigator: Navigator) {
+        onFragment { navigator.start(TestChildFragment.newInstance("SecondFragment")) }
+        moveToState(Lifecycle.State.RESUMED)
+        onFragment { navigator.goBack() }
+    }
+
+    private fun resetTabAndStartFragment(
+        navigator: Navigator,
+        expectedFragment: TestChildFragment
+    ): Result<Unit> {
+        return runCatching {
+            navigator.resetCurrentTab(true)
+            navigator.start(expectedFragment)
+        }
+    }
+
+    private fun TestParentFragment.createNavigator(rootFragment: TestChildFragment): MultipleStackNavigator {
+        return MultipleStackNavigator(
+            fragmentManager = this.childFragmentManager,
+            containerId = TestParentFragment.CONTAINER_ID,
+            rootFragmentProvider = listOf({ rootFragment }),
+            navigatorConfiguration = NavigatorConfiguration(
+                defaultNavigatorTransaction = NavigatorTransaction(TransactionType.SHOW_HIDE)
+            )
+        ).apply { this.initialize(null) }
+    }
+}

--- a/medusalib/src/main/java/com/trendyol/medusalib/navigator/controller/StagedFragmentHolder.kt
+++ b/medusalib/src/main/java/com/trendyol/medusalib/navigator/controller/StagedFragmentHolder.kt
@@ -1,0 +1,26 @@
+package com.trendyol.medusalib.navigator.controller
+
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+
+internal class StagedFragmentHolder constructor(
+    private val fragmentsByTags: MutableMap<String, Fragment>
+) {
+
+    fun stageFragmentForCommit(tag: String, fragment: Fragment) {
+        fragmentsByTags.put(tag, fragment)
+        fragment.lifecycle.addObserver(object : DefaultLifecycleObserver {
+
+            override fun onDestroy(owner: LifecycleOwner) {
+                fragmentsByTags.remove(tag)
+                fragment.lifecycle.removeObserver(this)
+                super.onDestroy(owner)
+            }
+        })
+    }
+
+    fun getStagedFragment(tag: String): Fragment? {
+        return fragmentsByTags.get(tag)
+    }
+}

--- a/medusalib/src/test/java/com/trendyol/medusalib/navigator/controller/StagedFragmentHolderTest.kt
+++ b/medusalib/src/test/java/com/trendyol/medusalib/navigator/controller/StagedFragmentHolderTest.kt
@@ -1,0 +1,69 @@
+package com.trendyol.medusalib.navigator.controller
+
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.fragment.app.testing.withFragment
+import com.google.common.truth.Truth
+import com.trendyol.medusalib.TestChildFragment
+import com.trendyol.medusalib.TestParentFragment
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class StagedFragmentHolderTest {
+
+    @Test
+    fun `given a fragment for a tag doesnt exist, when getStagedFragment is called, then it must return null`() {
+        val sut = StagedFragmentHolder(mutableMapOf())
+
+        val actualFragment = sut.getStagedFragment("missing-fragment")
+
+        Truth.assertThat(actualFragment).isNull()
+    }
+
+    @Test
+    fun `given a fragment for a tag exists, when getStagedFragment is called, then it must return that fragment`() {
+        val sut = StagedFragmentHolder(mutableMapOf())
+
+
+        launchFragmentInContainer { TestParentFragment() }.withFragment {
+            val fragmentToBeStaged = TestChildFragment.newInstance("title")
+            childFragmentManager
+                .beginTransaction()
+                .add(fragmentToBeStaged, "staged-child")
+                .commitNow()
+
+            sut.stageFragmentForCommit("staged-child", fragmentToBeStaged)
+
+            val actualFragment = sut.getStagedFragment("staged-child")
+
+            Truth.assertThat(actualFragment).isEqualTo(fragmentToBeStaged)
+        }
+    }
+
+    @Test
+    fun `given a fragment for a tag exists, when it is removed, then it must return null for that tag`() {
+        val sut = StagedFragmentHolder(mutableMapOf())
+
+
+        launchFragmentInContainer { TestParentFragment() }.withFragment {
+            val fragmentToBeStaged = TestChildFragment.newInstance("title")
+            childFragmentManager
+                .beginTransaction()
+                .add(fragmentToBeStaged, "staged-child")
+                .commitNow()
+            sut.stageFragmentForCommit("staged-child", fragmentToBeStaged)
+
+            childFragmentManager
+                .beginTransaction()
+                .remove(fragmentToBeStaged)
+                .commitNow()
+
+
+            val fragment = sut.getStagedFragment("staged-child")
+
+            Truth.assertThat(fragment).isNull()
+        }
+    }
+
+}


### PR DESCRIPTION
 Create stage fragment holder to hold fragment references by their tags until they're destroyed.

 FragmentManagerController use this class to retrieve fragment instances if it can't find those instances in FragmentManager.

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
