### PR TITLE
Fix root fragment is not being displayed after we call resetCurrentTa…

### DIFF
--- a/medusalib/src/androidTest/java/com/trendyol/medusalib/TestChildFragment.kt
+++ b/medusalib/src/androidTest/java/com/trendyol/medusalib/TestChildFragment.kt
@@ -26,6 +26,8 @@ class TestChildFragment : Fragment() {
         }
     }
 
+    fun requireArgumentTitle() = requireArguments().getString(KEY_TITLE)!!
+
     companion object {
         fun newInstance(title: String): TestChildFragment {
             return TestChildFragment().apply {

--- a/medusalib/src/androidTest/java/com/trendyol/medusalib/TestParentWithNavigatorFragment.kt
+++ b/medusalib/src/androidTest/java/com/trendyol/medusalib/TestParentWithNavigatorFragment.kt
@@ -1,0 +1,50 @@
+package com.trendyol.medusalib
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.fragment.app.Fragment
+import com.trendyol.medusalib.navigator.MultipleStackNavigator
+import com.trendyol.medusalib.navigator.Navigator
+import com.trendyol.medusalib.navigator.NavigatorConfiguration
+import com.trendyol.medusalib.navigator.transaction.NavigatorTransaction
+import com.trendyol.medusalib.navigator.transaction.TransactionType
+
+class TestParentWithNavigatorFragment : Fragment() {
+
+    lateinit var navigator: Navigator
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        navigator = createNavigator(
+            { TestChildFragment.newInstance("Root1") },
+            { TestChildFragment.newInstance("Root2") },
+            { TestChildFragment.newInstance("Root3") }
+        )
+        navigator.initialize(savedInstanceState)
+        return FrameLayout(requireContext()).apply { id = CONTAINER_ID }
+    }
+
+    fun createNavigator(
+        vararg rootFragments: () -> TestChildFragment
+    ): MultipleStackNavigator {
+        return MultipleStackNavigator(
+            fragmentManager = this.childFragmentManager,
+            containerId = TestParentFragment.CONTAINER_ID,
+            rootFragmentProvider = rootFragments.toList(),
+            navigatorConfiguration = NavigatorConfiguration(
+                defaultNavigatorTransaction = NavigatorTransaction(TransactionType.SHOW_HIDE)
+            )
+        )
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        navigator.onSaveInstanceState(outState)
+        super.onSaveInstanceState(outState)
+    }
+
+    companion object {
+        const val CONTAINER_ID = 1_000
+    }
+}

--- a/medusalib/src/androidTest/java/com/trendyol/medusalib/navigator/ActivityRecreationResetTabTest.kt
+++ b/medusalib/src/androidTest/java/com/trendyol/medusalib/navigator/ActivityRecreationResetTabTest.kt
@@ -1,0 +1,48 @@
+package com.trendyol.medusalib.navigator
+
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.lifecycle.Lifecycle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth
+import com.trendyol.medusalib.TestChildFragment
+import com.trendyol.medusalib.TestParentWithNavigatorFragment
+import org.junit.Test
+import org.junit.runner.RunWith
+
+
+@RunWith(AndroidJUnit4::class)
+class ActivityRecreationResetTabTest {
+
+    @Test
+    fun givenWithMultipleStackNavigatorWhenresetCurrentTabIsCalledAfterActionRecreationThenRootFragmentMustBevVisible() {
+        // Given
+        launchFragmentInContainer<TestParentWithNavigatorFragment>(
+            initialState = Lifecycle.State.INITIALIZED
+        )
+            .moveToState(Lifecycle.State.RESUMED)
+            .onFragment {
+                it.navigator.switchTab(2)
+                it.childFragmentManager.executePendingTransactions()
+
+                it.navigator.start(TestChildFragment.newInstance("Root3-1"))
+                it.childFragmentManager.executePendingTransactions()
+
+                it.navigator.start(TestChildFragment.newInstance("Root3-2"))
+                it.childFragmentManager.executePendingTransactions()
+            }
+            // When
+            .recreate()
+            // Then
+            .onFragment {
+                it.navigator.resetCurrentTab(resetRootFragment = false)
+                it.childFragmentManager.executePendingTransactions()
+                Truth.assertThat(
+                    it
+                        .childFragmentManager
+                        .fragments.first { (it as TestChildFragment).requireArgumentTitle() == "Root3" }
+                        .isVisible
+                ).isTrue()
+            }
+
+    }
+}

--- a/medusalib/src/main/java/com/trendyol/medusalib/navigator/MultipleStackNavigator.kt
+++ b/medusalib/src/main/java/com/trendyol/medusalib/navigator/MultipleStackNavigator.kt
@@ -164,7 +164,7 @@ open class MultipleStackNavigator(
             val upperFragment: Fragment? = fragmentManagerController.getFragment(upperFragmentTag)
 
             val newDestination: Fragment = upperFragment ?: getRootFragment(currentTabIndex)
-            val newDestinationTag: String = tagCreator.create(newDestination)
+            val newDestinationTag: String = newDestination.tag ?: tagCreator.create(newDestination)
 
             newDestination.observeFragmentLifecycle(
                 onViewCreated = ::onFragmentViewCreated,


### PR DESCRIPTION
Fix root fragment is not being displayed after we call resetCurrentTab following activity recreation

We were creating a new fragment instead of using the fragment tag that's already in FragmentManager

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
- Switch Tab
- Start a new fragment
- Trigger activity recreation or process death
- Click reset current tab without resetting root
- Ensure that root fragment is displayed properly
- 
## Motivation and Context

## How Has This Been Tested?
Manual and with an instrumentation test.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
