### PR TITLE
Preloaded fragment

### DIFF
--- a/app/src/main/java/com/trendyol/medusa/MainActivity.kt
+++ b/app/src/main/java/com/trendyol/medusa/MainActivity.kt
@@ -90,7 +90,7 @@ class MainActivity : AppCompatActivity(), Navigator.NavigatorListener {
             multipleStackNavigator.clearGroup("group1")
         }
         findViewById<Button>(R.id.startPreloadedFragment).setOnClickListener {
-            multipleStackNavigator.startPreloadFragment(SamplePreloadFragment.newInstance(), SamplePreloadFragment.TAG)
+            multipleStackNavigator.startPreloadedFragment(SamplePreloadFragment.newInstance(), SamplePreloadFragment.TAG)
         }
         multipleStackNavigator.observeDestinationChanges(this) {
             Log.d("Destination Changed", "${it.javaClass.name} - ${it.tag}")

--- a/app/src/main/java/com/trendyol/medusa/MainActivity.kt
+++ b/app/src/main/java/com/trendyol/medusa/MainActivity.kt
@@ -64,6 +64,11 @@ class MainActivity : AppCompatActivity(), Navigator.NavigatorListener {
 
         navigation = findViewById<View>(R.id.navigation) as BottomNavigationView
 
+        multipleStackNavigator.preloadFragment(
+            fragment = SamplePreloadFragment.newInstance(),
+            fragmentTag = SamplePreloadFragment.TAG
+        )
+
         multipleStackNavigator.initialize(savedInstanceState)
         val restartRootFragmentCheckBox = findViewById<View>(R.id.restartSwitch) as SwitchCompat
         findViewById<Button>(R.id.resetCurrentTab).setOnClickListener {
@@ -83,6 +88,9 @@ class MainActivity : AppCompatActivity(), Navigator.NavigatorListener {
         }
         findViewById<Button>(R.id.resetGroup).setOnClickListener {
             multipleStackNavigator.clearGroup("group1")
+        }
+        findViewById<Button>(R.id.startPreloadedFragment).setOnClickListener {
+            multipleStackNavigator.startPreloadFragment(SamplePreloadFragment.newInstance(), SamplePreloadFragment.TAG)
         }
         multipleStackNavigator.observeDestinationChanges(this) {
             Log.d("Destination Changed", "${it.javaClass.name} - ${it.tag}")

--- a/app/src/main/java/com/trendyol/medusa/SamplePreloadFragment.kt
+++ b/app/src/main/java/com/trendyol/medusa/SamplePreloadFragment.kt
@@ -9,7 +9,6 @@ import android.widget.Chronometer
 
 class SamplePreloadFragment : BaseFragment() {
 
-
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,

--- a/app/src/main/java/com/trendyol/medusa/SamplePreloadFragment.kt
+++ b/app/src/main/java/com/trendyol/medusa/SamplePreloadFragment.kt
@@ -1,0 +1,49 @@
+package com.trendyol.medusa
+
+import android.os.Bundle
+import android.os.CountDownTimer
+import android.os.SystemClock
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Chronometer
+
+class SamplePreloadFragment : BaseFragment() {
+
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        return inflater.inflate(R.layout.fragment_sample_preload, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        startTimer()
+    }
+
+    private fun startTimer() {
+        getChronometer().apply {
+            base = SystemClock.elapsedRealtime()
+            start()
+        }
+    }
+
+    private fun stopTimer() {
+        getChronometer().stop()
+    }
+
+    override fun onDestroyView() {
+        stopTimer()
+        super.onDestroyView()
+    }
+
+    private fun getChronometer(): Chronometer = requireView().findViewById(R.id.chronometer)
+
+    companion object {
+        const val TAG = "SamplePreloadFragmentTag"
+        fun newInstance(): SamplePreloadFragment = SamplePreloadFragment()
+    }
+}

--- a/app/src/main/java/com/trendyol/medusa/SamplePreloadFragment.kt
+++ b/app/src/main/java/com/trendyol/medusa/SamplePreloadFragment.kt
@@ -1,7 +1,6 @@
 package com.trendyol.medusa
 
 import android.os.Bundle
-import android.os.CountDownTimer
 import android.os.SystemClock
 import android.view.LayoutInflater
 import android.view.View

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -107,6 +107,19 @@
                     android:text="Reset Group" />
             </LinearLayout>
 
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <Button
+                    android:id="@+id/startPreloadedFragment"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:singleLine="true"
+                    android:text="Start Preloaded Fragment" />
+            </LinearLayout>
+
         </LinearLayout>
     </RelativeLayout>
 

--- a/app/src/main/res/layout/fragment_sample_preload.xml
+++ b/app/src/main/res/layout/fragment_sample_preload.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <Chronometer
+        android:id="@+id/chronometer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:textAlignment="center"
+        android:textSize="16sp" />
+
+</LinearLayout>

--- a/medusalib/build.gradle
+++ b/medusalib/build.gradle
@@ -43,7 +43,7 @@ android {
 
 ext {
     PUBLISH_GROUP_ID = 'com.trendyol'
-    PUBLISH_VERSION = '0.12.1'
+    PUBLISH_VERSION = '0.12.2'
     PUBLISH_ARTIFACT_ID = 'medusa'
     PUBLISH_DESCRIPTION = "Android Fragment Stack Controller"
     PUBLISH_URL = "https://github.com/Trendyol/medusa"

--- a/medusalib/src/androidTest/java/com/trendyol/medusalib/navigator/PreloadFragmentTest.kt
+++ b/medusalib/src/androidTest/java/com/trendyol/medusalib/navigator/PreloadFragmentTest.kt
@@ -1,0 +1,93 @@
+package com.trendyol.medusalib.navigator
+
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.lifecycle.Lifecycle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth
+import com.trendyol.medusalib.TestChildFragment
+import com.trendyol.medusalib.TestParentWithNavigatorFragment
+import com.trendyol.medusalib.navigator.controller.PreloadedFragmentResult
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PreloadFragmentTest {
+
+    @Test
+    fun testPreloadFragment() {
+        val scenario = launchFragmentInContainer<TestParentWithNavigatorFragment>()
+        scenario.moveToState(Lifecycle.State.RESUMED)
+
+        scenario.onFragment { parentFragment ->
+            val navigator = parentFragment.navigator
+
+            val fragmentTag = "preloaded_test_fragment"
+            val testChildFragment = TestChildFragment.newInstance("Preload Fragment")
+
+            navigator.preloadFragment(testChildFragment, fragmentTag)
+            parentFragment.childFragmentManager.executePendingTransactions()
+
+            val preloadedFragment = parentFragment.childFragmentManager.findFragmentByTag(fragmentTag)
+            Truth.assertThat(preloadedFragment).isNotNull()
+            Truth.assertThat(preloadedFragment?.isVisible).isFalse()
+        }
+    }
+
+    @Test
+    fun testStartPreloadedFragment() {
+        val scenario = launchFragmentInContainer<TestParentWithNavigatorFragment>()
+        scenario.moveToState(Lifecycle.State.RESUMED)
+        scenario.onFragment { parentFragment ->
+            val fragmentTag = "preloaded_test_fragment"
+            val navigator = parentFragment.navigator
+            val testChildFragment = TestChildFragment.newInstance("Preload Fragment")
+
+            navigator.preloadFragment(testChildFragment, fragmentTag)
+            parentFragment.childFragmentManager.executePendingTransactions()
+
+            val result = navigator.startPreloadFragment(null, fragmentTag)
+            parentFragment.childFragmentManager.executePendingTransactions()
+
+            Truth.assertThat(result).isEqualTo(PreloadedFragmentResult.Success)
+            val startedFragment = parentFragment.childFragmentManager.findFragmentByTag(fragmentTag)
+            Truth.assertThat(startedFragment).isNotNull()
+            Truth.assertThat(startedFragment?.isVisible).isTrue()
+        }
+    }
+
+    @Test
+    fun testStartPreloadedFragmentWithFallback() {
+        val scenario = launchFragmentInContainer<TestParentWithNavigatorFragment>()
+        scenario.moveToState(Lifecycle.State.RESUMED)
+        scenario.onFragment { parentFragment ->
+            val fragmentTag = "non_existent_fragment"
+            val navigator = parentFragment.navigator
+            val fallbackFragment = TestChildFragment.newInstance("Fallback Fragment")
+
+            val result = navigator.startPreloadFragment(fallbackFragment, fragmentTag)
+            parentFragment.childFragmentManager.executePendingTransactions()
+
+            val startedFragment = parentFragment.childFragmentManager.findFragmentByTag(fragmentTag)
+            Truth.assertThat(result).isEqualTo(PreloadedFragmentResult.FallbackSuccess)
+            Truth.assertThat(startedFragment).isNotNull()
+            Truth.assertThat(startedFragment?.isVisible).isTrue()
+        }
+    }
+
+    @Test
+    fun testStartPreloadedFragmentNotFound() {
+        val scenario = launchFragmentInContainer<TestParentWithNavigatorFragment>()
+        scenario.moveToState(Lifecycle.State.RESUMED)
+        scenario.onFragment { parentFragment ->
+            val fragmentTag = "non_existent_fragment"
+            val navigator = parentFragment.navigator
+
+            val result = navigator.startPreloadFragment(null, fragmentTag)
+            parentFragment.childFragmentManager.executePendingTransactions()
+
+            val fragment = parentFragment.childFragmentManager.findFragmentByTag(fragmentTag)
+            Truth.assertThat(result).isEqualTo(PreloadedFragmentResult.NotFound)
+            Truth.assertThat(fragment).isNull()
+        }
+    }
+}

--- a/medusalib/src/androidTest/java/com/trendyol/medusalib/navigator/PreloadFragmentTest.kt
+++ b/medusalib/src/androidTest/java/com/trendyol/medusalib/navigator/PreloadFragmentTest.kt
@@ -30,6 +30,7 @@ class PreloadFragmentTest {
             val preloadedFragment = parentFragment.childFragmentManager.findFragmentByTag(fragmentTag)
             Truth.assertThat(preloadedFragment).isNotNull()
             Truth.assertThat(preloadedFragment?.isVisible).isFalse()
+            Truth.assertThat(parentFragment.childFragmentManager.fragments.any { it.isVisible }).isTrue()
         }
     }
 
@@ -52,6 +53,9 @@ class PreloadFragmentTest {
             val startedFragment = parentFragment.childFragmentManager.findFragmentByTag(fragmentTag)
             Truth.assertThat(startedFragment).isNotNull()
             Truth.assertThat(startedFragment?.isVisible).isTrue()
+
+            val fragmentsWithoutPreloaded = parentFragment.childFragmentManager.fragments - startedFragment
+            Truth.assertThat(fragmentsWithoutPreloaded.all { it?.isVisible == false }).isTrue()
         }
     }
 
@@ -71,6 +75,9 @@ class PreloadFragmentTest {
             Truth.assertThat(result).isEqualTo(PreloadedFragmentResult.FallbackSuccess)
             Truth.assertThat(startedFragment).isNotNull()
             Truth.assertThat(startedFragment?.isVisible).isTrue()
+
+            val fragmentsWithoutPreloaded = parentFragment.childFragmentManager.fragments - startedFragment
+            Truth.assertThat(fragmentsWithoutPreloaded.all { it?.isVisible == false }).isTrue()
         }
     }
 
@@ -88,6 +95,7 @@ class PreloadFragmentTest {
             val fragment = parentFragment.childFragmentManager.findFragmentByTag(fragmentTag)
             Truth.assertThat(result).isEqualTo(PreloadedFragmentResult.NotFound)
             Truth.assertThat(fragment).isNull()
+            Truth.assertThat(parentFragment.childFragmentManager.fragments.any { it.isVisible }).isTrue()
         }
     }
 }

--- a/medusalib/src/androidTest/java/com/trendyol/medusalib/navigator/PreloadFragmentTest.kt
+++ b/medusalib/src/androidTest/java/com/trendyol/medusalib/navigator/PreloadFragmentTest.kt
@@ -46,7 +46,7 @@ class PreloadFragmentTest {
             navigator.preloadFragment(testChildFragment, fragmentTag)
             parentFragment.childFragmentManager.executePendingTransactions()
 
-            val result = navigator.startPreloadFragment(null, fragmentTag)
+            val result = navigator.startPreloadedFragment(null, fragmentTag)
             parentFragment.childFragmentManager.executePendingTransactions()
 
             Truth.assertThat(result).isEqualTo(PreloadedFragmentResult.Success)
@@ -68,7 +68,7 @@ class PreloadFragmentTest {
             val navigator = parentFragment.navigator
             val fallbackFragment = TestChildFragment.newInstance("Fallback Fragment")
 
-            val result = navigator.startPreloadFragment(fallbackFragment, fragmentTag)
+            val result = navigator.startPreloadedFragment(fallbackFragment, fragmentTag)
             parentFragment.childFragmentManager.executePendingTransactions()
 
             val startedFragment = parentFragment.childFragmentManager.findFragmentByTag(fragmentTag)
@@ -89,7 +89,7 @@ class PreloadFragmentTest {
             val fragmentTag = "non_existent_fragment"
             val navigator = parentFragment.navigator
 
-            val result = navigator.startPreloadFragment(null, fragmentTag)
+            val result = navigator.startPreloadedFragment(null, fragmentTag)
             parentFragment.childFragmentManager.executePendingTransactions()
 
             val fragment = parentFragment.childFragmentManager.findFragmentByTag(fragmentTag)

--- a/medusalib/src/main/java/com/trendyol/medusalib/navigator/MultipleStackNavigator.kt
+++ b/medusalib/src/main/java/com/trendyol/medusalib/navigator/MultipleStackNavigator.kt
@@ -63,7 +63,7 @@ open class MultipleStackNavigator(
         fragmentManagerController.preloadFragment(FragmentData(fragment, fragmentTag))
     }
 
-    override fun startPreloadFragment(fallbackFragment: Fragment?, fragmentTag: String): PreloadedFragmentResult {
+    override fun startPreloadedFragment(fallbackFragment: Fragment?, fragmentTag: String): PreloadedFragmentResult {
         val currentFragmentTag = getCurrentFragmentTag()
         val result = fragmentManagerController.showPreloadedFragment(currentFragmentTag, fragmentTag, fallbackFragment)
         if (result !is PreloadedFragmentResult.NotFound) {

--- a/medusalib/src/main/java/com/trendyol/medusalib/navigator/MultipleStackNavigator.kt
+++ b/medusalib/src/main/java/com/trendyol/medusalib/navigator/MultipleStackNavigator.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.MutableLiveData
 import com.trendyol.medusalib.navigator.controller.FragmentManagerController
+import com.trendyol.medusalib.navigator.controller.PreloadedFragmentResult
 import com.trendyol.medusalib.navigator.controller.StagedFragmentHolder
 import com.trendyol.medusalib.navigator.data.FragmentData
 import com.trendyol.medusalib.navigator.data.StackItem
@@ -56,6 +57,19 @@ open class MultipleStackNavigator(
 
     override fun start(fragment: Fragment, transitionAnimation: TransitionAnimationType) {
         start(fragment, DEFAULT_GROUP_NAME, transitionAnimation)
+    }
+
+    override fun preloadFragment(fragment: Fragment, fragmentTag: String) {
+        fragmentManagerController.preloadFragment(FragmentData(fragment, fragmentTag))
+    }
+
+    override fun startPreloadFragment(fallbackFragment: Fragment?, fragmentTag: String): PreloadedFragmentResult {
+        val currentFragmentTag = getCurrentFragmentTag()
+        val result = fragmentManagerController.showPreloadedFragment(currentFragmentTag, fragmentTag, fallbackFragment)
+        if (result !is PreloadedFragmentResult.NotFound) {
+            fragmentStackState.notifyStackItemAddToCurrentTab(StackItem(fragmentTag = fragmentTag))
+        }
+        return result
     }
 
     override fun start(fragment: Fragment, fragmentGroupName: String, transitionAnimation: TransitionAnimationType?) {

--- a/medusalib/src/main/java/com/trendyol/medusalib/navigator/Navigator.kt
+++ b/medusalib/src/main/java/com/trendyol/medusalib/navigator/Navigator.kt
@@ -3,6 +3,7 @@ package com.trendyol.medusalib.navigator
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
+import com.trendyol.medusalib.navigator.controller.PreloadedFragmentResult
 import com.trendyol.medusalib.navigator.transaction.NavigatorTransaction
 import com.trendyol.medusalib.navigator.transitionanimation.TransitionAnimationType
 
@@ -68,6 +69,36 @@ interface Navigator {
      * all fragments which has the same group name.
      */
     fun start(fragment: Fragment, transitionAnimation: TransitionAnimationType)
+
+    /**
+     * Preloads a fragment into the current navigation stack without immediately displaying it.
+     *
+     * This method attaches the given fragment to the fragment manager and prepares it in a hidden.
+     * The fragment will not be visible to the user until it is started later using
+     * [startPreloadFragment].
+     *
+     * @param fragment The fragment instance to preload.
+     * @param fragmentTag The unique tag of fragment.
+     */
+    fun preloadFragment(fragment: Fragment, fragmentTag: String)
+
+    /**
+     * Starts a fragment that was previously preloaded, making it visible.
+     *
+     * This method takes a previously preloaded fragment identified by its [fragmentTag] and brings it
+     * to the foreground. If the fragment was successfully preloaded, it will be shown immediately. If
+     * the fragment was not found or not preloaded, the optionally provided [fallbackFragment] will be added
+     * and displayed as a fallback.
+     *
+     * @param fallbackFragment Fragment instance to display if the preloaded fragment cannot be found.
+     * @param fragmentTag The unique tag of the previously preloaded fragment to start.
+     *
+     * @return [PreloadedFragmentResult]
+     * - [PreloadedFragmentResult.Success] if the preloaded fragment was found and displayed.
+     * - [PreloadedFragmentResult.FallbackSuccess] if the fallback fragment was used instead.
+     * - [PreloadedFragmentResult.NotFound] if no suitable fragment was found and no fallback was provided.
+     */
+    fun startPreloadFragment(fallbackFragment: Fragment?, fragmentTag: String): PreloadedFragmentResult
 
     /**
      * Modifies fragment stack. Pops current fragment from

--- a/medusalib/src/main/java/com/trendyol/medusalib/navigator/Navigator.kt
+++ b/medusalib/src/main/java/com/trendyol/medusalib/navigator/Navigator.kt
@@ -75,7 +75,7 @@ interface Navigator {
      *
      * This method attaches the given fragment to the fragment manager and prepares it in a hidden.
      * The fragment will not be visible to the user until it is started later using
-     * [startPreloadFragment].
+     * [startPreloadedFragment].
      *
      * @param fragment The fragment instance to preload.
      * @param fragmentTag The unique tag of fragment.
@@ -98,7 +98,7 @@ interface Navigator {
      * - [PreloadedFragmentResult.FallbackSuccess] if the fallback fragment was used instead.
      * - [PreloadedFragmentResult.NotFound] if no suitable fragment was found and no fallback was provided.
      */
-    fun startPreloadFragment(fallbackFragment: Fragment?, fragmentTag: String): PreloadedFragmentResult
+    fun startPreloadedFragment(fallbackFragment: Fragment?, fragmentTag: String): PreloadedFragmentResult
 
     /**
      * Modifies fragment stack. Pops current fragment from

--- a/medusalib/src/main/java/com/trendyol/medusalib/navigator/controller/FragmentManagerController.kt
+++ b/medusalib/src/main/java/com/trendyol/medusalib/navigator/controller/FragmentManagerController.kt
@@ -78,6 +78,32 @@ internal class FragmentManagerController(
         commitAllowingStateLoss()
     }
 
+    fun preloadFragment(fragmentData: FragmentData) {
+        checkAndCreateTransaction()
+        stageFragment(fragmentData)
+        currentTransaction?.add(containerId, fragmentData.fragment, fragmentData.fragmentTag)?.hide(fragmentData.fragment)
+        commitAllowingStateLoss()
+    }
+
+    fun showPreloadedFragment(
+        currentFragmentTag: String,
+        fragmentTag: String,
+        fallbackFragment: Fragment?,
+    ): PreloadedFragmentResult {
+        val fragment = getFragmentWithExecutingPendingTransactionsIfNeeded(fragmentTag) ?: fallbackFragment
+        if (fragment == null) return PreloadedFragmentResult.NotFound
+
+        disableFragment(currentFragmentTag)
+
+        return if (fragment != fallbackFragment) {
+            enableFragment(fragmentTag)
+            PreloadedFragmentResult.Success
+        } else {
+            addFragment(FragmentData(fallbackFragment, fragmentTag))
+            PreloadedFragmentResult.FallbackSuccess
+        }
+    }
+
     fun disableAndStartFragment(disableFragmentTag: String, vararg fragmentDataArgs: FragmentData) {
         val disabledFragment = getFragmentWithExecutingPendingTransactionsIfNeeded(disableFragmentTag)
 

--- a/medusalib/src/main/java/com/trendyol/medusalib/navigator/controller/PreloadedFragmentResult.kt
+++ b/medusalib/src/main/java/com/trendyol/medusalib/navigator/controller/PreloadedFragmentResult.kt
@@ -1,10 +1,22 @@
 package com.trendyol.medusalib.navigator.controller
 
+/**
+ * Represents the result of attempting to show a preloaded fragment.
+ */
 sealed interface PreloadedFragmentResult {
 
-    data object Success: PreloadedFragmentResult
+    /**
+     * Indicates that the preloaded fragment was successfully shown.
+     */
+    data object Success : PreloadedFragmentResult
 
-    data object FallbackSuccess: PreloadedFragmentResult
+    /**
+     * Indicates that a fallback fragment was used and successfully shown.
+     */
+    data object FallbackSuccess : PreloadedFragmentResult
 
-    data object NotFound: PreloadedFragmentResult
+    /**
+     * Indicates that neither the preloaded fragment nor a fallback fragment was found.
+     */
+    data object NotFound : PreloadedFragmentResult
 }

--- a/medusalib/src/main/java/com/trendyol/medusalib/navigator/controller/PreloadedFragmentResult.kt
+++ b/medusalib/src/main/java/com/trendyol/medusalib/navigator/controller/PreloadedFragmentResult.kt
@@ -1,0 +1,10 @@
+package com.trendyol.medusalib.navigator.controller
+
+sealed interface PreloadedFragmentResult {
+
+    data object Success: PreloadedFragmentResult
+
+    data object FallbackSuccess: PreloadedFragmentResult
+
+    data object NotFound: PreloadedFragmentResult
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added `preloadFragment` and `startPreloadFragment` to prepare fragments before they are shown.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Preloading allows fragments to be initialized in advance, ensuring they are ready to be displayed when needed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Implemented `PreloadFragmentTest` to verify that fragments are preloaded and then become visible as expected.

## Screenshots (if appropriate):
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
